### PR TITLE
Update to 2023.2.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/erocarrera/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0748ae46a3b93c5d393620c827874266c86ac81f52bf25fc08e7e95efff9e8f0
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,18 @@
 {% set name = "pefile" %}
-{% set version = "2022.5.30" %}
-{% set hash_type = "sha256" %}
-{% set hash = "a5488a3dd1fd021ce33f969780b88fe0f7eebb76eb20996d7318f307612a045b" %}
+{% set version = "2023.2.7" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  {{ hash_type }}: {{ hash }}
+  url: https://github.com/erocarrera/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 0748ae46a3b93c5d393620c827874266c86ac81f52bf25fc08e7e95efff9e8f0
 
 build:
   number: 0
   skip: true  # [py<36]
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   host:
@@ -25,7 +22,6 @@ requirements:
     - wheel
   run:
     - python
-    - future
 
 test:
   requires:


### PR DESCRIPTION
### Overview
Rebuild for pyinstaller rebuild for win. Updated to latest.

Dependency Chain:
`pefile` > `pyinstaller 5.13.2` (rebuild for win) > `pyinstaller-hooks-contrib` > `pyinstaller 6.7.0`

Related PRs:
[`pyinstaller` rebuild](https://github.com/AnacondaRecipes/pyinstaller-feedstock/pull/10)
[`pyinstaller-hooks-contrib`](https://github.com/AnacondaRecipes/pyinstaller-hooks-contrib-feedstock/pull/3)